### PR TITLE
Fixed some formatting, added py.typed and some linting

### DIFF
--- a/docs/examples/credits.ipynb
+++ b/docs/examples/credits.ipynb
@@ -44,7 +44,7 @@
     "\"\"\"\n",
     "\n",
     "with BQuery() as bq:\n",
-    "    df = bq.bql(query).combine()\n"
+    "    df = bq.bql(query).combine()"
    ]
   },
   {

--- a/examples/Examples-BQL.ipynb
+++ b/examples/Examples-BQL.ipynb
@@ -51,7 +51,7 @@
     "from polars_bloomberg import BQuery\n",
     "\n",
     "alt.renderers.enable(\"svg\")  # static charts\n",
-    "pl.Config.set_fmt_str_lengths(30)  # consistent display width for Polars\n"
+    "pl.Config.set_fmt_str_lengths(30)  # consistent display width for Polars"
    ]
   },
   {
@@ -210,7 +210,7 @@
     "\n",
     "# Combine the two DataFrames\n",
     "df = results.combine()\n",
-    "df\n"
+    "df"
    ]
   },
   {

--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -173,7 +173,8 @@
     "# Override string dates in format YYYYMMDD\n",
     "with BQuery() as bq:\n",
     "    df = bq.bdp(\n",
-    "        [\"USX60003AC87 Corp\"], [\"SETTLE_DT\"],\n",
+    "        [\"USX60003AC87 Corp\"],\n",
+    "        [\"SETTLE_DT\"],\n",
     "        overrides=[(\"USER_LOCAL_TRADE_DATE\", \"20241014\")],\n",
     "    )\n",
     "    print(df)"
@@ -537,7 +538,7 @@
     "\"\"\"\n",
     "with BQuery() as bq:\n",
     "    df_lst = bq.bql(query)\n",
-    "    print(df_lst[0].head(5))\n"
+    "    print(df_lst[0].head(5))"
    ]
   },
   {
@@ -575,7 +576,7 @@
     "        get(#eps)\n",
     "        for(['IBM US Equity'])\n",
     "    \"\"\")\n",
-    "    print(df_lst[0])\n"
+    "    print(df_lst[0])"
    ]
   },
   {
@@ -879,9 +880,9 @@
     "# https://github.com/MarekOzana/polars-bloomberg/issues/7\n",
     "\n",
     "with BQuery() as bq:\n",
-    "    result = bq.bql(\"for(['BFOR US Equity']) get(name)\") #   BARRON'S 400 ETF\n",
+    "    result = bq.bql(\"for(['BFOR US Equity']) get(name)\")  #   BARRON'S 400 ETF\n",
     "\n",
-    "print(result.combine())\n"
+    "print(result.combine())"
    ]
   },
   {
@@ -925,7 +926,7 @@
     "\"\"\"\n",
     "with BQuery() as bq:\n",
     "    df = bq.bql(query)[0]\n",
-    "print(df)\n"
+    "print(df)"
    ]
   }
  ],

--- a/polars_bloomberg/plbbg.py
+++ b/polars_bloomberg/plbbg.py
@@ -227,6 +227,8 @@ class BQuery:
 
     """
 
+    session: blpapi.Session
+
     def __init__(
         self,
         host: str = "localhost",
@@ -257,7 +259,6 @@ class BQuery:
         self.host = host
         self.port = port
         self.timeout = timeout
-        self.session = None
         self.debug = debug
 
     def __enter__(self):  # noqa: D105

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,14 @@ line-length = 89
 
 [tool.mypy]
 ignore_missing_imports = true
+
+
+[tool.uv.sources]
+blpapi = { index = "blpapi" }
+
+[[tool.uv.index]]
+name = "blpapi"
+url = "https://blpapi.bloomberg.com/repository/releases/python/simple"
+default = false
+explicit = true
+

--- a/tests/test_plbbg.py
+++ b/tests/test_plbbg.py
@@ -1299,7 +1299,8 @@ class TestBqlResult:
         with open(yaml_file) as f:
             d_lst = yaml.safe_load(f)
         df_lst = [pl.DataFrame(dct) for dct in d_lst]
-        bql_result = BqlResult(df_lst, names=list(range(len(df_lst))))
+        names = [str(x) for x in list(range(len(df_lst)))]
+        bql_result = BqlResult(df_lst, names=names)
 
         df = bql_result.combine().to_dict(as_series=False)
         assert df == exp_df

--- a/tests/test_plbbg.py
+++ b/tests/test_plbbg.py
@@ -7,6 +7,7 @@ The tests REQUIRE an active Bloomberg Terminal connection.
 """
 
 import json
+import re
 from collections.abc import Generator
 from datetime import date
 from typing import Final
@@ -934,14 +935,16 @@ class TestBqlResult:
         df2 = pl.DataFrame({"ID2": ["A", "B"], "Value2": [3, 4]})
         bql_result = BqlResult(dataframes=[df1, df2], names=["Data1", "Data2"])
 
-        with pytest.raises(ValueError, match="No common columns found to join on."):
+        with pytest.raises(
+            ValueError, match=re.escape("No common columns found to join on.")
+        ):
             bql_result.combine()
 
     def test_combine_empty_dataframes(self):
         """Test combining with no dataframes raises ValueError."""
         bql_result = BqlResult(dataframes=[], names=[])
 
-        with pytest.raises(ValueError, match="No DataFrames to combine."):
+        with pytest.raises(ValueError, match=re.escape("No DataFrames to combine.")):
             bql_result.combine()
 
     def test_getitem(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1684,7 +1684,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "altair", marker = "extra == 'dev'" },
-    { name = "blpapi", specifier = ">=3.24.0" },
+    { name = "blpapi", specifier = ">=3.24.0", index = "https://blpapi.bloomberg.com/repository/releases/python/simple" },
     { name = "great-tables", marker = "extra == 'docs'" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },


### PR DESCRIPTION
- Fixed formatting with Ruff
- Added `py.typed` file so upstream applications / libraries using mypy will work
- Fixed errors flagged by `ruff check` and `mypy .`
- Added blpapi index to pyproject.toml file so users of UV can sync